### PR TITLE
Replace different cases with the initial display value for stores

### DIFF
--- a/src/components/ListItemDisplay.tsx
+++ b/src/components/ListItemDisplay.tsx
@@ -65,11 +65,15 @@ const QuanityButton = styled.button<ButtonProps>`
 const DecreaseButton = styled( QuanityButton )`
   grid-area: Decrease;
   background-image: url('../Resources/ReduceItem.svg');
+  max-width: 50px;
+  max-height: 50px;
 `;
 
 const IncreaseButton = styled( QuanityButton )`
   grid-area: Increase;
   background-image: url('../Resources/IncreaseItem.svg');
+  max-width: 50px;
+  max-height: 50px;
 `;
 
 interface listDataProps{
@@ -118,7 +122,7 @@ function ListItemDisplay(
       <ItemPriceDisplay>
         R {' '}
         {
-          Math.ceil( listData?.price * listData.purchased )
+          Math.ceil( listData?.price )
         }
       </ItemPriceDisplay>
 

--- a/src/hooks/useStores.ts
+++ b/src/hooks/useStores.ts
@@ -10,7 +10,7 @@ interface useStoresResponse {
 }
 
 function useStores(): useStoresResponse {
-  const {context, storeContext, setStoreContext} = useContext( GLContext );
+  const {context, storeContext, setStoreContext, setContext} = useContext( GLContext );
 
   const standardizeName = ( storeName: string ): string => {
     return storeName
@@ -27,7 +27,9 @@ function useStores(): useStoresResponse {
 
     const tempStores = storeContext.stores.slice();
 
-    context.ListItems?.map( ( value ) => {
+    const tempContext = context;
+
+    tempContext.ListItems?.map( ( value ) => {
 
       const standardizedStore = standardizeName( value.store );
       const storeExists = tempStores.find( ( store ) => { return ( store?.value === standardizedStore ); } );
@@ -35,9 +37,13 @@ function useStores(): useStoresResponse {
       if ( !storeExists ) {
         tempStores.push( {value: standardizedStore, display: value.store} );
       }
+      else {
+        value.store = storeExists.display;
+      }
 
     } );
     setStoreContext( {stores: tempStores} );
+    setContext( tempContext );
 
     return ;
   };


### PR DESCRIPTION
Set maximum size for increment and decrement buttons: Should solve the scaling issue on desktop.
Store display values will now be replaced with the initial value typed for the store if it is typed again.
Price field will now show the price per item (I feel this is more intuitive rather than the price of purchased items. Perhaps we can replace this with the price * outstanding items instead, showing the total cost remaining?)